### PR TITLE
fixed issue with lpthread not being linked properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ else()
   message(WARNING "Chomod not found, solving will be significantly slower than expected.")
 endif()
 
+find_package(Threads)
+set(ALLLIBS ${ALLLIBS} ${CMAKE_THREAD_LIBS_INIT})
+
 ## FILES ##########################################################################
 set(SURFACE_MESH_SRC_FILES
     otlib/surface_mesh/IO.cpp
@@ -128,3 +131,4 @@ target_link_libraries(stippling otapputils otlib ${ALLLIBS})
 
 add_executable(barycenters apps/barycenters.cpp)
 target_link_libraries(barycenters otapputils otlib ${ALLLIBS})
+


### PR DESCRIPTION
/usr/bin/ld: libotapputils.a(image_utils.cpp.o): in function `cimg_library::cimg::Mutex_info::trylock(unsigned int)':
/home/alban/Documents/workspace/otmap/extern/CImg/CImg.h:3068: undefined reference to `pthread_mutex_trylock'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/otmap.dir/build.make:86: otmap] Error 1
make[1]: *** [CMakeFiles/Makefile2:148: CMakeFiles/otmap.dir/all] Error 2
make: *** [Makefile:84: all] Error 2